### PR TITLE
Changed Selected string in trip list CAB

### DIFF
--- a/app/src/main/java/com/nbossard/packlist/gui/TripDetailFragment.java
+++ b/app/src/main/java/com/nbossard/packlist/gui/TripDetailFragment.java
@@ -181,7 +181,7 @@ public class TripDetailFragment extends Fragment {
             mActionMode = getActivity().startActionMode(new ActionMode.Callback() {
                 @Override
                 public boolean onCreateActionMode(final ActionMode mode, final Menu menu) {
-                    mode.setTitle("Selected");
+                    mode.setTitle(getString(R.string.trip_detail__selected));
 
                     MenuInflater inflater = mode.getMenuInflater();
                     inflater.inflate(R.menu.menu_trip_detail_cab, menu);

--- a/app/src/main/java/com/nbossard/packlist/gui/TripListFragment.java
+++ b/app/src/main/java/com/nbossard/packlist/gui/TripListFragment.java
@@ -121,7 +121,7 @@ public class TripListFragment extends Fragment {
             mActionMode = getActivity().startActionMode(new ActionMode.Callback() {
                 @Override
                 public boolean onCreateActionMode(final ActionMode mode, final Menu menu) {
-                    mode.setTitle("Selected");
+                    mode.setTitle(getString(R.string.trip_detail__selected));
 
                     MenuInflater inflater = mode.getMenuInflater();
                     inflater.inflate(R.menu.menu_main_cab, menu);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="sorting_mode_unpacked_first">unpacked first</string>
     <string name="sorting_mode_alphabetical">alphabetical order</string>
     <string name="sorting_mode_category">category</string>
+    <string name="trip_detail__selected">Selected</string>
 
     <!-- Third party software licences -->
     <string name="help_legal__third_party__title">third party libraries</string>


### PR DESCRIPTION
This commit adds a new translatable string for the English word "Selected". It also changes the two appearances of the string "Selected" to a reference to this translatable string, particularly used in the Context Action Bar after long-clicking one of the items in the trip list.

Fixes issue #60 